### PR TITLE
fix build error in OTP19

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: false
 
 otp_release:
   - 18.0
+  - 19.0
 
 notifications:
   email: false

--- a/src/crypto_rsassa_pss.erl
+++ b/src/crypto_rsassa_pss.erl
@@ -42,7 +42,7 @@ sign(Message, DigestType, PrivateKey) when is_binary(Message) ->
 	sign({digest, crypto:hash(DigestType, Message)}, DigestType, PrivateKey);
 sign(Message={digest, _}, DigestType, PrivateKey) ->
 	SaltLen = byte_size(crypto:hash(DigestType, <<>>)),
-	Salt = crypto:rand_bytes(SaltLen),
+	Salt = crypto:strong_rand_bytes(SaltLen),
 	sign(Message, DigestType, Salt, PrivateKey).
 
 -spec sign(Message, DigestType, Salt, PrivateKey) -> Signature


### PR DESCRIPTION
crypto:rand_bytes/1 is deprecated and will be removed in a future release; use crypto:strong_rand_bytes/1